### PR TITLE
Feature with media pausing and cancelled train support

### DIFF
--- a/train-departures-android/build.gradle.kts
+++ b/train-departures-android/build.gradle.kts
@@ -19,6 +19,11 @@ android {
         isCheckReleaseBuilds = false
     }
     buildTypes {
+        getByName("debug") {
+            isMinifyEnabled = true // runProguard
+            isZipAlignEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+        }
         getByName("release") {
             isMinifyEnabled = true // runProguard
             isZipAlignEnabled = true

--- a/train-departures-android/src/main/java/uk/co/baconi/pka/td/DepartureSearchActivity.kt
+++ b/train-departures-android/src/main/java/uk/co/baconi/pka/td/DepartureSearchActivity.kt
@@ -2,6 +2,7 @@ package uk.co.baconi.pka.td
 
 import android.content.Context
 import android.content.Intent
+import android.media.AudioAttributes
 import android.os.Bundle
 import android.speech.tts.TextToSpeech
 import android.support.design.widget.Snackbar
@@ -23,8 +24,7 @@ import uk.co.baconi.pka.tdb.StationCode
 import uk.co.baconi.pka.tdb.StationCodes
 import uk.co.baconi.pka.tdb.openldbws.responses.DepartureItem
 import uk.co.baconi.pka.tdb.openldbws.responses.ServiceItem
-
-import java.util.UUID
+import java.util.*
 
 
 class DepartureSearchActivity : AppCompatActivity() {
@@ -44,7 +44,19 @@ class DepartureSearchActivity : AppCompatActivity() {
         val context: Context = this
 
         if(!this::textToSpeech.isInitialized) {
-            textToSpeech = TextToSpeech(context) {}
+
+            textToSpeech = TextToSpeech(context) {
+
+                // On Init Listener
+
+                textToSpeech.language = applicationContext.getCurrentLocale()
+
+                val audioAttributes = AudioAttributes.Builder()
+                    .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                    .build()
+
+                textToSpeech.setAudioAttributes(audioAttributes)
+            }
         }
 
         setContentView(R.layout.activity_departure_search)
@@ -169,8 +181,6 @@ class DepartureSearchActivity : AppCompatActivity() {
 
             // Can be used to detect errors during synthesis via setOnUtteranceProgressListener
             val utteranceId = UUID.randomUUID().toString()
-
-            textToSpeech.language = applicationContext.getCurrentLocale()
 
             // TODO - Check error/success response for queueing speech request
             textToSpeech.speak(speechText, TextToSpeech.QUEUE_FLUSH, null, utteranceId)

--- a/train-departures-android/src/main/java/uk/co/baconi/pka/td/SearchResultsAdapter.kt
+++ b/train-departures-android/src/main/java/uk/co/baconi/pka/td/SearchResultsAdapter.kt
@@ -67,6 +67,12 @@ class SearchResultsAdapter(private val searchResults: MutableList<ServiceItem>) 
                     R.color.search_result_departure_time_delayed
                 )
             }
+            "Cancelled" -> {
+                Pair(
+                    context.getString(R.string.search_result_delayed),
+                    R.color.search_result_departure_time_cancelled
+                )
+            }
             else -> { // Estimated
                 Pair(
                     service.etd,

--- a/train-departures-android/src/main/java/uk/co/baconi/pka/td/ServiceItemExtensions.kt
+++ b/train-departures-android/src/main/java/uk/co/baconi/pka/td/ServiceItemExtensions.kt
@@ -8,12 +8,14 @@ fun ServiceItem.tickerLine(context: Context): String = when(platform) {
         null -> context.getString(R.string.search_result_ticker_line_etd_other, std, destinationName, platform, std)
         "On time" -> context.getString(R.string.search_result_ticker_line_etd_on_time, std, destinationName, platform)
         "Delayed" -> context.getString(R.string.search_result_ticker_line_etd_delayed, std, destinationName, platform)
+        "Cancelled" -> context.getString(R.string.search_result_ticker_line_with_platform_cancelled, std, destinationName, platform)
         else -> context.getString(R.string.search_result_ticker_line_etd_other, std, destinationName, platform, etd)
     }
     else -> when(etd) {
         null -> context.getString(R.string.search_result_ticker_line_no_platform_etd_other, std, destinationName, std)
         "On time" -> context.getString(R.string.search_result_ticker_line_no_platform_etd_on_time, std, destinationName)
         "Delayed" -> context.getString(R.string.search_result_ticker_line_no_platform_etd_delayed, std, destinationName)
+        "Cancelled" -> context.getString(R.string.search_result_ticker_line_no_platform_cancelled, std, destinationName)
         else -> context.getString(R.string.search_result_ticker_line_no_platform_etd_other, std, destinationName, etd)
     }
 }

--- a/train-departures-android/src/main/java/uk/co/baconi/pka/td/Settings.kt
+++ b/train-departures-android/src/main/java/uk/co/baconi/pka/td/Settings.kt
@@ -16,6 +16,7 @@ sealed class Settings<A>(
     object EnableColouredDepartureTimes : Settings<Boolean>("enable_coloured_departure_times", true, SharedPreferences::getBoolean)
     object EnableSpeakingFirstResult : Settings<Boolean>("enable_speaking_first_result", true, SharedPreferences::getBoolean)
     object WhichSearchType : Settings<SearchType>("which_search_type", SearchType.MULTIPLE_RESULTS, ::getSearchType)
+    object WhichSpeechType : Settings<SpeechType>("which_speech_type", SpeechType.PAUSE_OTHER_SOUNDS, ::getSpeechType)
 
     fun getSetting(context: Context): A = getSetting(getPreferenceManager(context))
     private fun getSetting(sharedPreferences: SharedPreferences): A = provider.invoke(sharedPreferences, key, default)
@@ -24,6 +25,9 @@ sealed class Settings<A>(
         private fun getPreferenceManager(context: Context) = PreferenceManager.getDefaultSharedPreferences(context)
         private fun getSearchType(preferences: SharedPreferences, key: String, default: SearchType): SearchType {
             return preferences.getString(key, null).runCatching(SearchType::valueOf).getOrNull() ?: default
+        }
+        private fun getSpeechType(preferences: SharedPreferences, key: String, default: SpeechType): SpeechType {
+            return preferences.getString(key, null).runCatching(SpeechType::valueOf).getOrNull() ?: default
         }
     }
 }

--- a/train-departures-android/src/main/java/uk/co/baconi/pka/td/SpeechType.kt
+++ b/train-departures-android/src/main/java/uk/co/baconi/pka/td/SpeechType.kt
@@ -1,0 +1,6 @@
+package uk.co.baconi.pka.td
+
+enum class SpeechType {
+    PAUSE_OTHER_SOUNDS,
+    DIM_OTHER_SOUNDS
+}

--- a/train-departures-android/src/main/res/values/colors.xml
+++ b/train-departures-android/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="search_result_departure_time_default">#696969</color>
     <color name="search_result_departure_time_etd_unknown">#00B8D4</color>
     <color name="search_result_departure_time_on_time">#00C853</color>
-    <color name="search_result_departure_time_delayed">#D50000</color>
+    <color name="search_result_departure_time_delayed">#FFAB00</color>
     <color name="search_result_departure_time_estimated">#FF6D00</color>
+    <color name="search_result_departure_time_cancelled">#D50000</color>
 </resources>

--- a/train-departures-android/src/main/res/values/preferences.xml
+++ b/train-departures-android/src/main/res/values/preferences.xml
@@ -4,6 +4,7 @@
     <string name="pref_enable_coloured_avatars_title">Colour code platform number</string>
     <string name="pref_enable_coloured_departure_times_title">Colour code departure times</string>
     <string name="pref_which_search_type_title">Use which search type</string>
+    <string name="pref_which_speech_type_title">Use which speech type</string>
 
     <string-array name="pref_which_search_type_labels">
         <item>Single departure</item>
@@ -14,4 +15,15 @@
         <item>SINGLE_RESULT</item>
         <item>MULTIPLE_RESULTS</item>
     </string-array>
+
+    <string-array name="pref_which_speech_type_labels">
+        <item>Pause Media</item>
+        <item>Quieten Media</item>
+    </string-array>
+
+    <string-array name="pref_which_speech_type_values">
+        <item>PAUSE_OTHER_SOUNDS</item>
+        <item>DIM_OTHER_SOUNDS</item>
+    </string-array>
+
 </resources>

--- a/train-departures-android/src/main/res/values/strings.xml
+++ b/train-departures-android/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="search_criteria_to_label">To:</string>
 
     <string name="search_result_delayed">delayed</string>
+    <string name="search_result_cancelled">cancelled</string>
 
     <string name="search_result_destination">%1$s (%2$s)</string>
 
@@ -22,5 +23,8 @@
     <string name="search_result_ticker_line_no_platform_etd_on_time">The %1$s to %2$s is on time.</string>
     <string name="search_result_ticker_line_no_platform_etd_delayed">The %1$s to %2$s is delayed.</string>
     <string name="search_result_ticker_line_no_platform_etd_other">The %1$s to %2$s is expected at %3$s.</string>
+
+    <string name="search_result_ticker_line_with_platform_cancelled">The %1$s to %2$s on platform %3$s has been cancelled.</string>
+    <string name="search_result_ticker_line_no_platform_cancelled">The %1$s to %2$s has been cancelled.</string>
 
 </resources>

--- a/train-departures-android/src/main/res/xml/pref_general.xml
+++ b/train-departures-android/src/main/res/xml/pref_general.xml
@@ -33,4 +33,11 @@
         android:entries="@array/pref_which_search_type_labels"
         android:entryValues="@array/pref_which_search_type_values"/>
 
+    <ListPreference
+        android:key="which_speech_type"
+        android:defaultValue="PAUSE_OTHER_SOUNDS"
+        android:title="@string/pref_which_speech_type_title"
+        android:entries="@array/pref_which_speech_type_labels"
+        android:entryValues="@array/pref_which_speech_type_values"/>
+
 </PreferenceScreen>


### PR DESCRIPTION
- Adds the option of either pausing or dimming any music playing when speaking, this should help close off #4 

- Adds in a new set of checks for outright cancelled trains and a minor shuffle in colours.